### PR TITLE
Migration to set post decorator class in existing installations.

### DIFF
--- a/db/migrate/20160825174848_set_cama_post_decorator_class.rb
+++ b/db/migrate/20160825174848_set_cama_post_decorator_class.rb
@@ -1,0 +1,13 @@
+class SetCamaPostDecoratorClass < ActiveRecord::Migration
+  def change
+    CamaleonCms::Site.reset_column_information
+    CamaleonCms::PostType.reset_column_information
+    CamaleonCms::Site.find_each do |site|
+      post_type = site.post_types.where(slug: 'commerce').first
+      if post_type
+        post_type.set_options(cama_post_decorator_class: 'Plugins::Ecommerce::ProductDecorator')
+        post_type.save(validate: false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The post decorator class must be set to Plugins::Ecommerce::ProductDecorator
otherwise code like (product).decorated.price fails thusly:

NoMethodError: undefined method `price' for #CamaleonCms::PostDecorator:0x0055628d7d6578
