### PR TITLE
Some changes to checkout flow

### DIFF
--- a/app/helpers/plugins/ecommerce/ecommerce_email_helper.rb
+++ b/app/helpers/plugins/ecommerce/ecommerce_email_helper.rb
@@ -2,7 +2,10 @@ module Plugins::Ecommerce::EcommerceEmailHelper
   include CamaleonCms::EmailHelper
 
   def mark_order_like_received(cart, status = 'paid')
-    order = cart.make_paid!(status)
+    cart.prepare_to_pay
+    cart.update_amounts
+    cart.mark_paid(status)
+    order = cart.convert_to_order
 
     # send email to buyer
     commerce_send_order_received_email(order)

--- a/app/helpers/plugins/ecommerce/ecommerce_email_helper.rb
+++ b/app/helpers/plugins/ecommerce/ecommerce_email_helper.rb
@@ -15,6 +15,8 @@ module Plugins::Ecommerce::EcommerceEmailHelper
 
     flash[:notice] = t('plugins.ecommerce.messages.payment_completed', default: "Payment completed successfully")
     args = {order: order}; hooks_run("commerce_after_payment_completed", args)
+    
+    order
   end
 
   def commerce_send_order_received_email(order, is_after_bank_confirmation = false)

--- a/app/models/plugins/ecommerce/cart.rb
+++ b/app/models/plugins/ecommerce/cart.rb
@@ -89,7 +89,6 @@ class Plugins::Ecommerce::Cart < ActiveRecord::Base
   # convert into order current cart
   def convert_to_order
     self.update_columns(kind: 'order', created_at: Time.current)
-    self.metas.update_all(object_class: 'Plugins::Ecommerce::Order')
     site.orders.find(self.id)
   end
 

--- a/app/models/plugins/ecommerce/cart.rb
+++ b/app/models/plugins/ecommerce/cart.rb
@@ -134,7 +134,12 @@ class Plugins::Ecommerce::Cart < ActiveRecord::Base
   def make_paid!(status = 'paid')
     product_items.decorate.each do |item|
       p = item.product.decorate
-      item.update_columns(cache_the_price: p.the_price(item.variation_id), cache_the_title: p.the_variation_title(item.variation_id), cache_the_tax: p.the_tax(item.variation_id), cache_the_sub_total: item.the_sub_total)
+      item.update_columns(
+        cache_the_price: p.the_price(item.variation_id),
+        cache_the_title: p.the_variation_title(item.variation_id),
+        cache_the_tax: p.the_tax(item.variation_id),
+        cache_the_sub_total: item.the_sub_total,
+      )
     end
 
     if self.coupon.present?
@@ -145,7 +150,17 @@ class Plugins::Ecommerce::Cart < ActiveRecord::Base
       end
     end
     c = self.decorate
-    self.update_columns(status: status, paid_at: Time.current, amount: total_amount, cache_the_total: c.the_price, cache_the_sub_total: c.the_sub_total, cache_the_tax: c.the_tax_total, cache_the_weight: c.the_weight_total, cache_the_discounts: c.the_total_discounts, cache_the_shipping: c.the_total_shipping)
+    self.update_columns(
+      status: status,
+      paid_at: Time.current,
+      amount: total_amount,
+      cache_the_total: c.the_price,
+      cache_the_sub_total: c.the_sub_total,
+      cache_the_tax: c.the_tax_total,
+      cache_the_weight: c.the_weight_total,
+      cache_the_discounts: c.the_total_discounts,
+      cache_the_shipping: c.the_total_shipping,
+    )
     make_order!
   end
 


### PR DESCRIPTION
Old flow had some problems:
- quantities were decremented after user was charged,
  creating a possibility of a user paying for something that was out of stock
- names did not reflect what the methods did
- code was not grouped into methods logically

Changes here:
- add a state "qtys_taken" to the cart;
  this is set after product quantities have been decremented
- user is charged after product quantities have been incremented
  and cart is in qtys_taken state
- code that updates amounts and totals in the car moved to its own method
- make_paid! renamed to mark_paid, it now just does what its name implies
- make_order! renamed to convert_to_order, it aso now only does what its name implies

Also reverts #45, it seems that metas do need to stay attached to carts.
