### PR TITLE
Cart service & more

### DIFF
--- a/app/controllers/plugins/ecommerce/front/checkout_controller.rb
+++ b/app/controllers/plugins/ecommerce/front/checkout_controller.rb
@@ -134,7 +134,14 @@ class Plugins::Ecommerce::Front::CheckoutController < Plugins::Ecommerce::FrontC
 
   def pay_by_authorize_net
     res = Plugins::Ecommerce::CartService.new(current_site, @cart).
-      pay_with_authorize_net(payment_method: @payment, ip: request.remote_ip)
+      pay_with_authorize_net(payment_method: @payment, ip: request.remote_ip,
+        first_name: params[:firstName],
+        last_name: params[:lastName],
+        number: params[:cardNumber],
+        exp_month: params[:expMonth],
+        exp_year: params[:expYear],
+        cvc: params[:cvCode],
+      )
     if res[:error].present?
       flash[:error] = res[:error]
       flash[:payment_error] = true

--- a/app/controllers/plugins/ecommerce/front/checkout_controller.rb
+++ b/app/controllers/plugins/ecommerce/front/checkout_controller.rb
@@ -133,7 +133,8 @@ class Plugins::Ecommerce::Front::CheckoutController < Plugins::Ecommerce::FrontC
   end
 
   def pay_by_authorize_net
-    res = payment_pay_by_credit_card_authorize_net(@cart, @payment)
+    res = Plugins::Ecommerce::CartService.new(current_site, @cart).
+      pay_with_authorize_net(@payment, ip: request.remote_ip)
     if res[:error].present?
       flash[:error] = res[:error]
       flash[:payment_error] = true

--- a/app/controllers/plugins/ecommerce/front/checkout_controller.rb
+++ b/app/controllers/plugins/ecommerce/front/checkout_controller.rb
@@ -110,7 +110,7 @@ class Plugins::Ecommerce::Front::CheckoutController < Plugins::Ecommerce::FrontC
 
   def pay_by_stripe
     result = Plugins::Ecommerce::CartService.new(current_site, @cart).
-      pay_with_stripe(@payment,
+      pay_with_stripe(payment_method: @payment,
         email: params[:stripeEmail],
         stripe_token: params[:stripeToken],
       )
@@ -134,7 +134,7 @@ class Plugins::Ecommerce::Front::CheckoutController < Plugins::Ecommerce::FrontC
 
   def pay_by_authorize_net
     res = Plugins::Ecommerce::CartService.new(current_site, @cart).
-      pay_with_authorize_net(@payment, ip: request.remote_ip)
+      pay_with_authorize_net(payment_method: @payment, ip: request.remote_ip)
     if res[:error].present?
       flash[:error] = res[:error]
       flash[:payment_error] = true
@@ -158,7 +158,7 @@ class Plugins::Ecommerce::Front::CheckoutController < Plugins::Ecommerce::FrontC
 
   def pay_by_paypal
     result = Plugins::Ecommerce::CartService.new(current_site, @cart).
-      pay_with_paypal(@payment, ip: request.remote_ip)
+      pay_with_paypal(payment_method: @payment, ip: request.remote_ip)
     redirect_to result[:redirect_url]
   end
 

--- a/app/controllers/plugins/ecommerce/front/checkout_controller.rb
+++ b/app/controllers/plugins/ecommerce/front/checkout_controller.rb
@@ -163,35 +163,9 @@ class Plugins::Ecommerce::Front::CheckoutController < Plugins::Ecommerce::FrontC
   end
 
   def pay_by_paypal
-    billing_address = @cart.get_meta("billing_address")
-    ActiveMerchant::Billing::Base.mode = @payment.options[:paypal_sandbox].to_s.to_bool ? :test : :production
-    paypal_options = {
-      :login => @payment.options[:paypal_login],
-      :password => @payment.options[:paypal_password],
-      :signature => @payment.options[:paypal_signature]
-    }
-    @gateway = ActiveMerchant::Billing::PaypalExpressGateway.new(paypal_options)
-    @options = {
-      brand_name: current_site.name,
-      items: [{number: @cart.slug, name: "Buy Products from #{current_site.the_title}: #{@cart.products_title}", amount: commerce_to_cents(@cart.total_amount)}],
-      :order_id => @cart.slug,
-      :currency => current_site.currency_code,
-      :email => @cart.user.email,
-      :billing_address => {:name => "#{billing_address[:first_name]} #{billing_address[:last_name]}",
-                           :address1 => billing_address[:address1],
-                           :address2 => billing_address[:address2],
-                           :city => billing_address[:city],
-                           :state => billing_address[:state],
-                           :country => billing_address[:country],
-                           :zip => billing_address[:zip]
-      },
-      :description => "Buy Products from #{current_site.the_title}: #{@cart.total_amount}",
-      :ip => request.remote_ip,
-      :return_url => plugins_ecommerce_checkout_success_paypal_url(order: @cart.slug),
-      :cancel_return_url => plugins_ecommerce_checkout_cancel_paypal_url(order: @cart.slug)
-    }
-    response = @gateway.setup_purchase(commerce_to_cents(@cart.total_amount), @options)
-    redirect_to @gateway.redirect_url_for(response.token)
+    result = Plugins::Ecommerce::CartService.new(current_site, @cart).
+      pay_with_paypal(@payment, ip: request.remote_ip)
+    redirect_to result[:redirect_url]
   end
 
   private

--- a/app/helpers/plugins/ecommerce/ecommerce_payment_helper.rb
+++ b/app/helpers/plugins/ecommerce/ecommerce_payment_helper.rb
@@ -1,11 +1,6 @@
 module Plugins::Ecommerce::EcommercePaymentHelper
   include Plugins::Ecommerce::EcommerceHelper
 
-  def payment_pay_by_credit_card_authorize_net(cart, payment_method)
-    Plugins::Ecommerce::CartService.new(current_site, cart).
-      pay_with_authorize_net(payment_method, ip: request.remote_ip)
-  end
-
   def commerce_to_cents(money)
     Plugins::Ecommerce::UtilService.ecommerce_money_to_cents(money)
   end

--- a/app/helpers/plugins/ecommerce/ecommerce_payment_helper.rb
+++ b/app/helpers/plugins/ecommerce/ecommerce_payment_helper.rb
@@ -2,56 +2,12 @@ module Plugins::Ecommerce::EcommercePaymentHelper
   include Plugins::Ecommerce::EcommerceHelper
 
   def payment_pay_by_credit_card_authorize_net(order, payment_method)
-    billing_address = order.get_meta("billing_address")
-    details = order.get_meta("details")
-    amount = commerce_to_cents(order.total_amount)
-    payment_params = {
-      :order_id => order.slug,
-      :currency => current_site.currency_code,
-      :email => order.user.email,
-      :billing_address => {:name => "#{order.user.fullname}",
-                           :address1 => billing_address[:address1],
-                           :address2 => billing_address[:address2],
-                           :city => billing_address[:city],
-                           :state => billing_address[:state],
-                           :country => billing_address[:country],
-                           :zip => billing_address[:zip]
-      },
-      :description => 'Buy Products',
-      :ip => request.remote_ip
-    }
-
-    authorize_net_options = {
-      :login => payment_method.options[:authorize_net_login_id],
-      :password => payment_method.options[:authorize_net_transaction_key]
-    }
-
-    ActiveMerchant::Billing::Base.mode = payment_method.options[:authorize_net_sandbox].to_s.to_bool ? :test : :production
-
-    credit_card = ActiveMerchant::Billing::CreditCard.new(
-      :first_name => params[:firstName],
-      :last_name => params[:lastName],
-      :number => params[:cardNumber],
-      :month => params[:expMonth],
-      :year => "20#{params[:expYear]}",
-      :verification_value => params[:cvCode]
-    )
-    if credit_card.validate.empty?
-      gateway = ActiveMerchant::Billing::AuthorizeNetGateway.new(authorize_net_options)
-      response = gateway.purchase(amount, credit_card, payment_params)
-      if response.success?
-        order.set_meta('pay_authorize_net', payment_params)
-        return {}
-      else
-        return {error: response.message}
-      end
-    else
-      return {error: credit_card.validate.map{|k, v| "#{k}: #{v.join(', ')}"}.join('<br>')}
-    end
+    Plugins::Ecommerce::CartService.new(current_site, order).
+      pay_with_authorize_net(payment_method, ip: request.remote_ip)
   end
 
   def commerce_to_cents(money)
-    (money*100).round
+    Plugins::Ecommerce::UtilService.ecommerce_money_to_cents(money)
   end
 
   def commerce_current_currency

--- a/app/helpers/plugins/ecommerce/ecommerce_payment_helper.rb
+++ b/app/helpers/plugins/ecommerce/ecommerce_payment_helper.rb
@@ -1,8 +1,8 @@
 module Plugins::Ecommerce::EcommercePaymentHelper
   include Plugins::Ecommerce::EcommerceHelper
 
-  def payment_pay_by_credit_card_authorize_net(order, payment_method)
-    Plugins::Ecommerce::CartService.new(current_site, order).
+  def payment_pay_by_credit_card_authorize_net(cart, payment_method)
+    Plugins::Ecommerce::CartService.new(current_site, cart).
       pay_with_authorize_net(payment_method, ip: request.remote_ip)
   end
 

--- a/app/helpers/plugins/ecommerce/ecommerce_payment_helper.rb
+++ b/app/helpers/plugins/ecommerce/ecommerce_payment_helper.rb
@@ -10,8 +10,4 @@ module Plugins::Ecommerce::EcommercePaymentHelper
     Plugins::Ecommerce::UtilService.ecommerce_money_to_cents(money)
   end
 
-  def commerce_current_currency
-    current_site.get_meta("_setting_ecommerce", {})[:current_unit] || 'USD'
-  end
-
 end

--- a/app/helpers/plugins/ecommerce/ecommerce_payment_helper.rb
+++ b/app/helpers/plugins/ecommerce/ecommerce_payment_helper.rb
@@ -1,6 +1,4 @@
 module Plugins::Ecommerce::EcommercePaymentHelper
-  include Plugins::Ecommerce::EcommerceHelper
-
   def commerce_to_cents(money)
     Plugins::Ecommerce::UtilService.ecommerce_money_to_cents(money)
   end

--- a/app/services/plugins/ecommerce/cart_service.rb
+++ b/app/services/plugins/ecommerce/cart_service.rb
@@ -1,0 +1,61 @@
+class Plugins::Ecommerce::CartService
+  def initialize(site, cart)
+    @site = site
+    @cart = cart
+  end
+  
+  attr_reader :site, :cart
+  
+  def pay_with_authorize_net(payment_method, options={})
+    billing_address = cart.get_meta("billing_address")
+    details = cart.get_meta("details")
+    amount = Plugins::Ecommerce::UtilService.ecommerce_money_to_cents(cart.total_amount)
+    payment_params = {
+      :order_id => cart.slug,
+      :currency => site.currency_code,
+      :email => cart.user.email,
+      :billing_address => {:name => "#{cart.user.fullname}",
+                           :address1 => billing_address[:address1],
+                           :address2 => billing_address[:address2],
+                           :city => billing_address[:city],
+                           :state => billing_address[:state],
+                           :country => billing_address[:country],
+                           :zip => billing_address[:zip]
+      },
+      :description => 'Buy Products',
+      :ip => request.remote_ip
+    }
+    
+    if options[:ip]
+      payment_params[:ip] = options[:ip]
+    end
+
+    authorize_net_options = {
+      :login => payment_method.options[:authorize_net_login_id],
+      :password => payment_method.options[:authorize_net_transaction_key]
+    }
+
+    ActiveMerchant::Billing::Base.mode = payment_method.options[:authorize_net_sandbox].to_s.to_bool ? :test : :production
+
+    credit_card = ActiveMerchant::Billing::CreditCard.new(
+      :first_name => params[:firstName],
+      :last_name => params[:lastName],
+      :number => params[:cardNumber],
+      :month => params[:expMonth],
+      :year => "20#{params[:expYear]}",
+      :verification_value => params[:cvCode]
+    )
+    if credit_card.validate.empty?
+      gateway = ActiveMerchant::Billing::AuthorizeNetGateway.new(authorize_net_options)
+      response = gateway.purchase(amount, credit_card, payment_params)
+      if response.success?
+        cart.set_meta('pay_authorize_net', payment_params)
+        return {}
+      else
+        return {error: response.message}
+      end
+    else
+      return {error: credit_card.validate.map{|k, v| "#{k}: #{v.join(', ')}"}.join('<br>')}
+    end
+  end
+end

--- a/app/services/plugins/ecommerce/cart_service.rb
+++ b/app/services/plugins/ecommerce/cart_service.rb
@@ -58,4 +58,47 @@ class Plugins::Ecommerce::CartService
       return {error: credit_card.validate.map{|k, v| "#{k}: #{v.join(', ')}"}.join('<br>')}
     end
   end
+  
+  def pay_with_paypal(payment_method, options={})
+    billing_address = cart.get_meta("billing_address")
+    ActiveMerchant::Billing::Base.mode = payment_method.options[:paypal_sandbox].to_s.to_bool ? :test : :production
+    paypal_options = {
+      :login => payment_method.options[:paypal_login],
+      :password => payment_method.options[:paypal_password],
+      :signature => payment_method.options[:paypal_signature]
+    }
+    gateway = ActiveMerchant::Billing::PaypalExpressGateway.new(paypal_options)
+    amount_in_cents = Plugins::Ecommerce::UtilService.ecommerce_money_to_cents(cart.total_amount)
+    gateway_request = {
+      brand_name: site.name,
+      items: [{
+        number: cart.slug,
+        name: "Buy Products from #{site.the_title}: #{cart.products_title}",
+        amount: amount_in_cents,
+      }],
+      :order_id => cart.slug,
+      :currency => site.currency_code,
+      :email => cart.user.email,
+      :billing_address => {:name => "#{billing_address[:first_name]} #{billing_address[:last_name]}",
+                           :address1 => billing_address[:address1],
+                           :address2 => billing_address[:address2],
+                           :city => billing_address[:city],
+                           :state => billing_address[:state],
+                           :country => billing_address[:country],
+                           :zip => billing_address[:zip]
+      },
+      :description => "Buy Products from #{site.the_title}: #{cart.total_amount}",
+      :ip => request.remote_ip,
+      :return_url => plugins_ecommerce_checkout_success_paypal_url(order: @cart.slug),
+      :cancel_return_url => plugins_ecommerce_checkout_cancel_paypal_url(order: @cart.slug)
+    }
+    
+    if options[:ip]
+      gateway_request[:ip] = options[:ip]
+    end
+    
+    response = gateway.setup_purchase(amount_in_cents, gateway_request)
+    # TODO handle errors
+    {redirect_url: gateway.redirect_url_for(response.token)}
+  end
 end

--- a/app/services/plugins/ecommerce/site_service.rb
+++ b/app/services/plugins/ecommerce/site_service.rb
@@ -1,0 +1,21 @@
+class Plugins::Ecommerce::SiteService
+  def initialize(site)
+    @site = site
+  end
+  
+  attr_reader :site
+  
+  def currency
+    site.get_meta("_setting_ecommerce", {})[:current_unit] || 'USD'
+  end
+  
+  def payment_method(type)
+    payment_method = site.payment_methods.actives.detect do |payment_method|
+      payment_method.get_option('type') == type
+    end
+    if payment_method.nil?
+      raise ArgumentError, "Payment method #{type} is not found"
+    end
+    payment_method
+  end
+end

--- a/app/services/plugins/ecommerce/util_service.rb
+++ b/app/services/plugins/ecommerce/util_service.rb
@@ -1,0 +1,5 @@
+class Plugins::Ecommerce::UtilService
+  def self.ecommerce_money_to_cents(money)
+    (money*100).round
+  end
+end


### PR DESCRIPTION
In this PR:
- created a Cart service which encapsulates paying for the cart via the 3 available payment methods (vs having that code be spread over 2 files without much structure)
- return values/error reporting is now consistent across all  3 payment methods
- made some parameter names consistent as well
- the Cart service is usable by an api controller
- added a helper to retrieve payment methods by type and a Site service to house it
- other helpers moved to services to clearly indicate dependencies, or lack thereof
- I tested the stripe path, we no longer use paypal/authorize.net paths
