### PR TITLE
Fix English translations

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,4 @@
-﻿﻿en:
+en:
   plugins:
     ecommerce:
       currencies:


### PR DESCRIPTION
English translations were missing because the en.yml had some invalid characters in the key. It doesnt show in the diff but previously there were two asterisks before `en:`